### PR TITLE
Fix categories (v1): static legacy redirect for /category → /blog/category

### DIFF
--- a/app/blog/category/page.tsx
+++ b/app/blog/category/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { getAllPosts } from '@/lib/posts.server'
+
+function slugify(str: string) {
+  return str.toLowerCase().replace(/\s+/g, '-')
+}
+
+async function getAllCategories() {
+  const posts = await getAllPosts()
+  const categories = new Map<string, string>()
+  posts.forEach(post => {
+    const slug = slugify(post.category)
+    if (!categories.has(slug)) {
+      categories.set(slug, post.category)
+    }
+  })
+  return Array.from(categories.entries()).map(([slug, name]) => ({ slug, name }))
+}
+
+export const dynamic = 'error'
+
+export default async function CategoryIndexPage() {
+  const categories = await getAllCategories()
+  return (
+    <div className="container mx-auto px-4 py-16 mt-16">
+      <div className="max-w-6xl mx-auto">
+        <header className="mb-12">
+          <h1 className="text-3xl sm:text-4xl font-bold mb-4">Categories</h1>
+        </header>
+        <ul className="space-y-2">
+          {categories.map(({ slug, name }) => (
+            <li key={slug}>
+              <Link href={`/blog/category/${slug}/`}>{name}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/category/[category]/page.tsx
+++ b/app/category/[category]/page.tsx
@@ -1,0 +1,29 @@
+import { getAllPosts } from '@/lib/posts.server'
+import type { Metadata } from 'next'
+
+function slugify(str: string) {
+  return str.toLowerCase().replace(/\s+/g, '-')
+}
+
+export async function generateMetadata({ params }: { params: { category: string } }): Promise<Metadata> {
+  const target = `/blog/category/${params.category}/`
+  return {
+    refresh: `0;url=${target}`,
+  }
+}
+
+export default function LegacyCategoryRedirect({ params }: { params: { category: string } }) {
+  const target = `/blog/category/${params.category}/`
+  return (
+    <p>
+      Redirecting to <a href={target}>{target}</a>...
+      <script dangerouslySetInnerHTML={{ __html: `window.location.href='${target}'` }} />
+    </p>
+  )
+}
+
+export async function generateStaticParams() {
+  const posts = await getAllPosts()
+  const categories = Array.from(new Set(posts.map(post => slugify(post.category))))
+  return categories.map(category => ({ category }))
+}

--- a/content/posts/2024-01-09-ps2exe-backup-automation.md
+++ b/content/posts/2024-01-09-ps2exe-backup-automation.md
@@ -3,6 +3,7 @@ title: "Converting PowerShell Scripts to EXE with PS2EXE: A Real-World Example"
 description: "Learn how to convert PowerShell scripts into standalone executables using PS2EXE, with a practical example of automating Excel file backups to OneDrive."
 date: "2024-01-09"
 category: "PowerShell"
+categories: ["PowerShell"]
 ---
 
 # Converting PowerShell Scripts to EXE with PS2EXE: A Real-World Example


### PR DESCRIPTION
## Summary
- remove Next.js redirect to stay compatible with static export
- add legacy `/category/:slug` page with meta refresh and JS redirect to `/blog/category/:slug`
- generate category pages and index from post front matter, including example `categories: ["PowerShell"]`

## Testing
- `npm install`
- `npm run build` *(fails: Objects are not valid as a React child; export errors for /blog/[slug], /blog/category/[category], /blog)*


------
https://chatgpt.com/codex/tasks/task_e_68aa81dba58883259e97170080da8ab5