### PR TITLE
Fix blog post date parsing for PSAppDeployToolkit article

### DIFF
--- a/content/posts/2024-12-14-PSAppDeployToolkitv4-Intune-Deep-Dive.md
+++ b/content/posts/2024-12-14-PSAppDeployToolkitv4-Intune-Deep-Dive.md
@@ -1,6 +1,6 @@
 ---
 title: "10 Things I Learned About Planning a Windows 11 Rollout"
-date: 2025-03-28
+date: "2025-03-28"
 draft: false
 tags: ["Windows 11", "Intune", "SCCM", "AutoPatch", "Azure", "Migration", "Digital Transformation"]
 summary: "Rolling out Windows 11 at enterprise scale isn’t just about pushing an upgrade. It’s about flattening complexity, scrutinising policies, and setting clear milestones. Here are 10 lessons I learned along the way."


### PR DESCRIPTION
### Summary
- Quote the front-matter `date` so the PSAppDeployToolkit article parses as a string and no longer crashes the build.

### Testing
- `npm install`
- `NEXT_IGNORE_INCOMPATIBLE_LOCKFILE=1 NEXT_TELEMETRY_DISABLED=1 npm run build` *(fails: lockfile patch ENETUNREACH)*
- `test -f out/blog/category/powershell/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68aa81dba58883259e97170080da8ab5