### PR TITLE
Remove unsupported redirects from Next.js export build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,11 +6,6 @@ const nextConfig = {
   },
   basePath: '',
   trailingSlash: true,
-  async redirects() {
-    return [
-      { source: '/category/:slug', destination: '/blog/category/:slug', permanent: true },
-    ]
-  },
   typescript: {
     // Temporarily ignore type errors during build
     ignoreBuildErrors: true,


### PR DESCRIPTION
## Summary
- remove `redirects` block from Next.js config to support static export

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab0324825483258c113b87b1738b35