### PR TITLE
fix: remove deprecated Next.js config options

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,12 +14,6 @@ const nextConfig = {
     // Temporarily ignore eslint errors during build
     ignoreDuringBuilds: true,
   },
-  experimental: {
-    // Enable if needed
-    appDir: true,
-  },
-  // Ensure all pages are generated at build time
-  generateStaticParams: true,
   // Generate 404 page
   generateBuildId: async () => 'build',
   // Add assetPrefix for production


### PR DESCRIPTION
## Summary
- remove deprecated `experimental.appDir` and invalid `generateStaticParams` options from `next.config.js`

## Testing
- `npm run build` *(fails: Failed to patch lockfile, please try uninstalling and reinstalling next)*
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac32ebed38832589a626460cf18cc2