### PR TITLE
Sanitize blog slug generation to remove punctuation

### DIFF
--- a/lib/posts.server.ts
+++ b/lib/posts.server.ts
@@ -32,7 +32,10 @@ export async function getAllPosts() {
     const title = isNonEmptyString(data.title) ? data.title : file.replace(/\.(md|mdx)$/, '')
     const slug = isNonEmptyString(data.slug)
       ? data.slug
-      : title.toLowerCase().replace(/\s+/g, '-')
+      : title
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '')
 
     const date = toISODate(data.date) || ''
     const category = isNonEmptyString(data.category) ? data.category : 'Uncategorized'


### PR DESCRIPTION
## Summary
- strip non-alphanumeric characters when deriving post slugs to avoid broken URLs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run build` *(fails: ENETUNREACH while patching lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b1845b26ec8325a00d4549c6fd9ccb